### PR TITLE
Unification of functions using RGB mode (set_rgb and start_cf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ typings/
 
 # next.js build output
 .next
+
+#DestroyCom contribution exclusion
+.prettierignore
+destcom

--- a/lib/Yeelight.js
+++ b/lib/Yeelight.js
@@ -371,7 +371,9 @@ class Yeelight extends EventEmitter {
        */
 
       const flowExpression = flow.reduce((accum, curr) => {
-        curr[2] = this._rgbConvert(curr[2]);
+        if (typeof curr[2] === 'object') {
+            curr[2] = this._rgbConvert(curr[2]);
+        }
         return `${accum}${accum ? "," : ""}${curr.join(",")}`;
       }, "");
 

--- a/lib/Yeelight.js
+++ b/lib/Yeelight.js
@@ -84,6 +84,21 @@ class Yeelight extends EventEmitter {
     }
 
     /**
+     * Convert RGB array to the 24-bit format used by Yeelight.
+     *
+     * @param {Array} rgb Array of R,G,B as values between 0 and 255
+     * As the docs say's, RGB values had to follow the calculation code of (R*65536) + (G*256) + B
+     * @returns {Number} The 24-bit color value
+     */
+    _rgbConvert(rgb = [255, 255, 255]) {
+      const rgbValue =
+        this._constrain(rgb[0], 0, 255) * 65536 +
+        this._constrain(rgb[1], 0, 255) * 256 +
+        this._constrain(rgb[2], 0, 255);
+      return rgbValue;
+    }
+
+    /**
      * Return a boolean indicating whether or not the needle is present in the haystack.
      * 
      * @param {*} needle What you are searching for
@@ -182,10 +197,7 @@ class Yeelight extends EventEmitter {
      * @param {Number} duration
      */
     set_rgb(rgb = [255, 255, 255], effect = 'smooth', duration = 500) {
-        const rgbValue =
-            (this._constrain(rgb[0], 0, 255) * 65536) +
-            (this._constrain(rgb[1], 0, 255) * 256) +
-            (this._constrain(rgb[2], 0, 255))
+        const rgbValue = this._rgbConvert(rgb);
         return this._sendCommand({
             method: 'set_rgb',
             params: [
@@ -343,29 +355,30 @@ class Yeelight extends EventEmitter {
      * @param {Number} count The number of state changes before color flow stops. 0 = infinite
      * @param {Number} action The action after stopping CF. 0 = revert to previous state, 1 stay at state when stopped, 2 = turn off smart LED
      * @param {Array} flow A series of tuples defining the [duration, mode, value, brightness]
+     * 
+     * Exemple start_cf(0,0,[[500,1,[255,12,45],99], [2500,1,[45,24,32],30], [1000,1,[200,200,100],99]])
      */
     start_cf(count = 0, action = 0, flow = []) {
-        /**
-         * The flow expression is composed by combining the given flow array into a string.
-         * The flow array should consist of arrays, each containing 4 values.
-         * [
-         *  duration -- time in ms for the transition,
-         *  mode -- 1 == color, 2 == color temperature, 7 == sleep,
-         *  value -- RGB value for mode 1, CT value for mode 2, ignored for mode 7,
-         *  brightness -- value between 1 and 100
-         * ]
-         */
-        const flowExpression = flow.reduce((accum, curr) => {
-            return `${accum}${accum?',':''}${curr.join(',')}`
-        }, '')
-        return this._sendCommand({
-            method: 'start_cf',
-            params: [
-                count || 0,
-                this._ifValid(action, [0, 1, 2], 0),
-                flowExpression
-            ]
-        })
+      /**
+       * The flow expression is composed by combining the given flow array into a string.
+       * The flow array should consist of arrays, each containing 4 values.
+       * [
+       *  duration -- time in ms for the transition,
+       *  mode -- 1 == color, 2 == color temperature, 7 == sleep,
+       *  value -- RGB array [R,G,B] for mode 1, CT value for mode 2, ignored for mode 7,
+       *  brightness -- value between 1 and 100
+       * ]
+       */
+
+      const flowExpression = flow.reduce((accum, curr) => {
+        curr[2] = this._rgbConvert(curr[2]);
+        return `${accum}${accum ? "," : ""}${curr.join(",")}`;
+      }, "");
+
+      return this._sendCommand({
+        method: "start_cf",
+        params: [count || 0, this._ifValid(action, [0, 1, 2], 0), flowExpression],
+      });
     }
 
     /**


### PR DESCRIPTION
When using the library, I tried to use the color flow mode, and I didn't immediately understand how to do it because the method of set_rgb and start_cf are different

So I propose this pull request, which unifies the use of the functions, by doing the calculation for both of them.

File edited : 
- ./lib/Yeelight.js
- ./.gitignore