### PR TITLE
fix RGB color value of 0 for legacy bulbs ("color" model)

### DIFF
--- a/lib/Yeelight.js
+++ b/lib/Yeelight.js
@@ -2,6 +2,8 @@ const EventEmitter = require('events')
 const net = require('net')
 
 class Yeelight extends EventEmitter {
+    static detectLegacy = false;
+
     constructor(config = {}) {
         super()
         this.id = config.id || 0
@@ -34,6 +36,13 @@ class Yeelight extends EventEmitter {
             this.connected = false
         })
         this.connected = true
+
+        // if detectLegacy is true, automatically get model and set as property
+        if ( ! this.model && Yeelight.detectLegacy ) {
+            this.get_prop('model').then((r) => {
+                this.model = JSON.parse(r)?.result?.[0];
+            });
+        }
     }
 
     /**
@@ -355,7 +364,25 @@ class Yeelight extends EventEmitter {
          *  brightness -- value between 1 and 100
          * ]
          */
-        const flowExpression = flow.reduce((accum, curr) => {
+        let flowExpression = flow;
+        // for legacy models, change flow steps that turn the bulb off by setting an RGB color value of 0,
+        // which would otherwise result in an error and not start the flow
+        if ( this.model === 'color' ) {
+            flowExpression = flow.map( step => {
+                let stepCopy = [...step];
+                // if rgb color value = 0
+                if ( stepCopy[1] == 1 && stepCopy[2] == 0 ) {
+                    // change mode to 3
+                    stepCopy[1] = 3;
+                    // set color and brightness to 0
+                    stepCopy[2] = 0;
+                    stepCopy[3] = 0;
+                }
+                return stepCopy;
+            } );
+        }
+
+        flowExpression = flowExpression.reduce((accum, curr) => {
             return `${accum}${accum?',':''}${curr.join(',')}`
         }, '')
         return this._sendCommand({


### PR DESCRIPTION
This fixes #10. Recent models (at least bulbs identifying as model "colorb", e.g. YLDP005) support setting an rgb value of 0 in a color flow step, which will turn off the light for that step. Older models (identifying simply as "color", e.g. YLDP06YL) do not support that and will silently fail (unless you log the error returned by the request), not starting the color flow at all.

This PR lets you do the following: Setting the constant `Yeelight.detectLegacy` to `true`, the bulb model wil be queried when the bulb connects. Alternatively, you can set the model to `colorb` yourself for those bulbs in the config object of the Yeelight constructor.

For bulbs of the "colorb" model, any color flow steps that contain an rgb value of 0 will be adapted to set an undocumented color mode "3" in order to turn off the bulb instead.